### PR TITLE
fix: rename string and integer option

### DIFF
--- a/schemas/actions/function/option.json
+++ b/schemas/actions/function/option.json
@@ -14,7 +14,7 @@
           "$ref": "/bettyblocks/json-schema/master/schemas/actions/function/option/types/collection.json"
         },
         {
-          "$ref": "/bettyblocks/json-schema/master/schemas/actions/function/option/types/integer.json"
+          "$ref": "/bettyblocks/json-schema/master/schemas/actions/function/option/types/number.json"
         },
         {
           "$ref": "/bettyblocks/json-schema/master/schemas/actions/function/option/types/model.json"
@@ -23,7 +23,7 @@
           "$ref": "/bettyblocks/json-schema/master/schemas/actions/function/option/types/record.json"
         },
         {
-          "$ref": "/bettyblocks/json-schema/master/schemas/actions/function/option/types/string.json"
+          "$ref": "/bettyblocks/json-schema/master/schemas/actions/function/option/types/text.json"
         }
       ]
     },

--- a/schemas/actions/function/option/types/base.json
+++ b/schemas/actions/function/option/types/base.json
@@ -6,8 +6,8 @@
   "type": "object",
   "properties": {
     "type": {
-      "description": "The type of option you want to supply. Examples are: Boolean, Integer and Model.",
-      "enum": ["Boolean", "Collection", "Integer", "Model", "Record", "String"]
+      "description": "The type of option you want to supply. Examples are: Boolean, Number and Model.",
+      "enum": ["Boolean", "Collection", "Number", "Model", "Record", "Text"]
     },
     "io": {
       "description": "Determines if this option is input or output. Output should be supplied in the function implementation. Input will be resolved by the Actions engine.",

--- a/schemas/actions/function/option/types/number.json
+++ b/schemas/actions/function/option/types/number.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/bettyblocks/json-schema/master/schemas/actions/function/option/types/integer.json",
-  "title": "Options Type Integer",
-  "description": "Properties specific to the Integer option type.",
+  "$id": "https://raw.githubusercontent.com/bettyblocks/json-schema/master/schemas/actions/function/option/types/number.json",
+  "title": "Options Type Number",
+  "description": "Properties specific to the Number option type.",
   "type": "object",
   "allOf": [
     {
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "type": {
-      "const": "Integer"
+      "const": "Number"
     },
     "min": {
       "description": "The minimum value of the option",

--- a/schemas/actions/function/option/types/text.json
+++ b/schemas/actions/function/option/types/text.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/bettyblocks/json-schema/master/schemas/actions/function/option/types/string.json",
-  "title": "Options Type String",
-  "description": "Properties specific to the String option type.",
+  "$id": "https://raw.githubusercontent.com/bettyblocks/json-schema/master/schemas/actions/function/option/types/text.json",
+  "title": "Options Type Text",
+  "description": "Properties specific to the Text option type.",
   "type": "object",
   "allOf": [
     {
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "type": {
-      "const": "String"
+      "const": "Text"
     },
     "default": {
       "description": "The default value of the option",


### PR DESCRIPTION
Rename the `Integer` and `String` option to `Number` and `Text`